### PR TITLE
Add missing global OAuth2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,6 +54,7 @@ module.exports = {
         Maps: false,
         MimeType: false,
         Mirror: false,
+        OAuth2: false,
         People: false,
         PropertiesService: false,
         ScriptApp: false,


### PR DESCRIPTION
The keyword OAuth2 is missing from the configuration of globals provided by this eslint plugin. My PR adds it.